### PR TITLE
feat(exclusive-limiting): support arbitrary limit behavior + rate limiting implementation

### DIFF
--- a/bigbuff.go
+++ b/bigbuff.go
@@ -166,15 +166,19 @@ type (
 		work  map[interface{}]*exclusiveItem
 	}
 
+	// WorkFunc is a work function, as used by Exclusive.
+	WorkFunc func(resolve func(result interface{}, err error))
+
 	// ExclusiveOption passes configuration into Exclusive.CallWithOptions, see also package functions prefixed with
 	// Exclusive, such as ExclusiveKey and ExclusiveWork.
 	ExclusiveOption func(c *exclusiveConfig)
 
 	exclusiveConfig struct {
-		key   interface{}
-		work  func(resolve func(result interface{}, err error))
-		wait  time.Duration
-		start bool
+		key      interface{}
+		work     WorkFunc
+		wait     time.Duration
+		start    bool
+		wrappers []func(value WorkFunc) WorkFunc
 	}
 
 	// ExclusiveOutcome is the return value from an async bigbuff.Exclusive call
@@ -187,7 +191,7 @@ type (
 		mutex    *sync.Mutex
 		cond     *sync.Cond
 		ts       time.Time
-		work     func(resolve func(result interface{}, err error))
+		work     WorkFunc
 		wait     time.Duration
 		running  bool
 		complete bool

--- a/bigbuff.go
+++ b/bigbuff.go
@@ -172,7 +172,7 @@ type (
 
 	exclusiveConfig struct {
 		key   interface{}
-		work  func() (interface{}, error)
+		work  func(resolve func(result interface{}, err error))
 		wait  time.Duration
 		start bool
 	}
@@ -186,7 +186,9 @@ type (
 	exclusiveItem struct {
 		mutex    *sync.Mutex
 		cond     *sync.Cond
-		work     func() (interface{}, error)
+		ts       time.Time
+		work     func(resolve func(result interface{}, err error))
+		wait     time.Duration
 		running  bool
 		complete bool
 		count    int

--- a/bigbuff.go
+++ b/bigbuff.go
@@ -166,6 +166,17 @@ type (
 		work  map[interface{}]*exclusiveItem
 	}
 
+	// ExclusiveOption passes configuration into Exclusive.CallWithOptions, see also package functions prefixed with
+	// Exclusive, such as ExclusiveKey and ExclusiveWork.
+	ExclusiveOption func(c *exclusiveConfig)
+
+	exclusiveConfig struct {
+		key   interface{}
+		work  func() (interface{}, error)
+		wait  time.Duration
+		start bool
+	}
+
 	// ExclusiveOutcome is the return value from an async bigbuff.Exclusive call
 	ExclusiveOutcome struct {
 		Result interface{}

--- a/exclusive_test.go
+++ b/exclusive_test.go
@@ -728,7 +728,7 @@ func BenchmarkExclusive_outcomeContention(b *testing.B) {
 					defer close(initialIn)
 					initialOut := make(chan struct{})
 					defer close(initialOut)
-					initialOutcome := exclusive.CallWithOptions(ExclusiveWork(func() (interface{}, error) {
+					initialOutcome := exclusive.CallWithOptions(exclusiveValue(func() (interface{}, error) {
 						initialIn <- struct{}{}
 						<-initialOut
 						return 123, nil
@@ -749,7 +749,7 @@ func BenchmarkExclusive_outcomeContention(b *testing.B) {
 
 					for i := 0; i < tc.Count; i++ {
 						go func() {
-							v := <-exclusive.CallWithOptions(ExclusiveWork(func() (interface{}, error) {
+							v := <-exclusive.CallWithOptions(exclusiveValue(func() (interface{}, error) {
 								in <- struct{}{}
 								return 456, nil
 							}))


### PR DESCRIPTION
This change makes it possible to apply limits to non-start calls, without introducing a "delay" in the outcome of said calls, using the `Exclusive` implementation in this package.

This expands support for a common pattern involving blocking the work function, after any operation that requires some form of limiting (e.g. rate limiting applied using the `MinDuration` function). The same sort of pattern may still be used, see also the new `ExclusiveRateLimit` function.

Note that the `Exclusive` call (and start) methods have been consolidated into a single options-style method, `CallWithOptions` (the older methods are still and will remain supported / aren't deprecated).

This change does incur a performance hit, and a benchmark has been added to monitor this. Though further optimisation will likely be carried out, and it will be monitored closely, testing indicates that (potentially depending on platform and use case) any discernible difference is unlikely.